### PR TITLE
Fixed crashing when passed file that is not a .txt

### DIFF
--- a/app.js
+++ b/app.js
@@ -62,10 +62,9 @@ app.post('/api/phonenumbers/parse/file', function(req, res) {
 		
 			buffer.toString().split(/\n/).forEach(function(line){
 				try{
-					var num = line.replace(/\D/g, '');	//get rid of alphabetic characters
-					var temp = phoneUtil.parse(num,'CA');
-					if(!isEmpty(temp) && phoneUtil.isValidNumber(temp)){
-						list.push(phoneUtil.format(temp,PNF.INTERNATIONAL));
+					var num = phoneUtil.parse(line.replace(/\D/g, ''),'CA');//get rid of alphabetic characters
+					if(!isEmpty(num) && phoneUtil.isValidNumber(num)){
+						list.push(phoneUtil.format(num,PNF.INTERNATIONAL));
 					}
 				}
 				catch(err){

--- a/app.js
+++ b/app.js
@@ -16,8 +16,8 @@ router.get('/api/phonenumbers/parse/text/:phoneNum',(req, res) => {
 	var num = req.params.phoneNum.toString().replace(/\D/g, '');
 	var list = [];
 
-	if(req.params.phoneNum == 'nothing' || req.params.phoneNum == '' || num.length < 10 || num.length > 11){
-		res.status(400).send([]);
+	if(num.length < 10 || num.length > 11 || (num.toString().charAt(0) != "1" && num.length == 11)){
+		res.status(400).send("Invalid Number");
 	}
 	else{
 		var phoneNumber = phoneUtil.parse(num, 'CA');
@@ -56,19 +56,20 @@ app.post('/api/phonenumbers/parse/file', function(req, res) {
 		}
 	}).single('userFile');
 	upload(req, res, function(err) {
-		var buffer = fs.readFileSync(req.file.path);
-		buffer.toString().split(/\n/).forEach(function(line){
-			try {
-				var num = line.replace(/\D/g, '');	//get rid of alphabetic characters
-				var temp = phoneUtil.parse(num,'CA');
-				if(!isEmpty(temp) && phoneUtil.isValidNumber(temp)){
-					list.push(phoneUtil.format(temp,PNF.INTERNATIONAL));
-				}
-			} catch(err) {
-
-			}
-		});
-		res.status(200).send(list);
+		try{
+			var buffer = fs.readFileSync(req.file.path);
+			buffer.toString().split(/\n/).forEach(function(line){
+					var num = line.replace(/\D/g, '');	//get rid of alphabetic characters
+					var temp = phoneUtil.parse(num,'CA');
+					if(!isEmpty(temp) && phoneUtil.isValidNumber(temp)){
+						list.push(phoneUtil.format(temp,PNF.INTERNATIONAL));
+					}
+			});
+			res.status(200).send(list);
+		}
+		catch (err){
+			res.status(400).send("Bad File");
+		}
 	})
 });
 


### PR DESCRIPTION
Fixed issue where passing anything other than a .txt or no file at all would result in a crash. Along with that I fixed the issue where the get would parse numbers that were 11 characters long but had an invalid area code. Also I removed some unnecessary temp variables.